### PR TITLE
Explicit link to libatomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,11 @@ if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
     find_package(Threads)
-    find_library(SDL2_LIBRARY NAME SDL2 HINTS /usr/lib/x86_64-linux-gnu)
-    find_library(PORTAUDIO_LIBRARY NAME portaudio HINTS /usr/lib/x86_64-linux-gnu)
-    find_library(VORBIS_LIBRARY NAME vorbis HINTS /usr/lib/x86_64-linux-gnu)
-    find_library(VORBIS_FILE_LIBRARY NAME vorbisfile HINTS /usr/lib/x86_64-linux-gnu)
+    find_library(ATOMIC_LIBRARY NAMES atomic atomic.so.1 libatomic.so.1 HINTS /usr/lib/${CMAKE_C_LIBRARY_ARCHITECTURE} PATH_SUFFIXES )
+    find_library(SDL2_LIBRARY NAME SDL2 HINTS /usr/lib/${CMAKE_C_LIBRARY_ARCHITECTURE})
+    find_library(PORTAUDIO_LIBRARY NAME portaudio HINTS /usr/lib/${CMAKE_C_LIBRARY_ARCHITECTURE})
+    find_library(VORBIS_LIBRARY NAME vorbis HINTS /usr/lib/${CMAKE_C_LIBRARY_ARCHITECTURE})
+    find_library(VORBIS_FILE_LIBRARY NAME vorbisfile HINTS /usr/lib/${CMAKE_C_LIBRARY_ARCHITECTURE})
 endif()
 
 add_executable(visuals ${FILES})
@@ -24,6 +25,7 @@ if (NOT WIN32)
     target_link_libraries(visuals
         ${CMAKE_DL_LIBS}
         ${CMAKE_THREAD_LIBS_INIT}
+	${ATOMIC_LIBRARY}
         ${PORTAUDIO_LIBRARY}
         ${VORBIS_LIBRARY}
         ${VORBIS_FILE_LIBRARY}


### PR DESCRIPTION
We need this because of the use of atomic objects with sizes that aren't
supported natively by the CPU.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>